### PR TITLE
Add capacity bounds to `read_map` and `read_seq`.

### DIFF
--- a/src/collection_impls.rs
+++ b/src/collection_impls.rs
@@ -30,7 +30,7 @@ impl<
 
 impl<T:Decodable> Decodable for LinkedList<T> {
     fn decode<D: Decoder>(d: &mut D) -> Result<LinkedList<T>, D::Error> {
-        d.read_seq(|d, len| {
+        d.read_seq(|d, len, _| {
             let mut list = LinkedList::new();
             for i in 0..len {
                 list.push_back(try!(d.read_seq_elt(i, |d| Decodable::decode(d))));
@@ -53,7 +53,7 @@ impl<T: Encodable> Encodable for VecDeque<T> {
 
 impl<T:Decodable> Decodable for VecDeque<T> {
     fn decode<D: Decoder>(d: &mut D) -> Result<VecDeque<T>, D::Error> {
-        d.read_seq(|d, len| {
+        d.read_seq(|d, len, _| {
             let mut deque: VecDeque<T> = VecDeque::new();
             for i in 0..len {
                 deque.push_back(try!(d.read_seq_elt(i, |d| Decodable::decode(d))));
@@ -85,7 +85,7 @@ impl<
     V: Decodable + PartialEq
 > Decodable for BTreeMap<K, V> {
     fn decode<D: Decoder>(d: &mut D) -> Result<BTreeMap<K, V>, D::Error> {
-        d.read_map(|d, len| {
+        d.read_map(|d, len, _| {
             let mut map = BTreeMap::new();
             for i in 0..len {
                 let key = try!(d.read_map_elt_key(i, |d| Decodable::decode(d)));
@@ -116,7 +116,7 @@ impl<
     T: Decodable + PartialEq + Ord
 > Decodable for BTreeSet<T> {
     fn decode<D: Decoder>(d: &mut D) -> Result<BTreeSet<T>, D::Error> {
-        d.read_seq(|d, len| {
+        d.read_seq(|d, len, _| {
             let mut set = BTreeSet::new();
             for i in 0..len {
                 set.insert(try!(d.read_seq_elt(i, |d| Decodable::decode(d))));
@@ -148,8 +148,8 @@ impl<K, V> Decodable for HashMap<K, V>
           V: Decodable,
 {
     fn decode<D: Decoder>(d: &mut D) -> Result<HashMap<K, V>, D::Error> {
-        d.read_map(|d, len| {
-            let mut map = HashMap::with_capacity(len);
+        d.read_map(|d, len, capacity| {
+            let mut map = HashMap::with_capacity(capacity);
             for i in 0..len {
                 let key = try!(d.read_map_elt_key(i, |d| Decodable::decode(d)));
                 let val = try!(d.read_map_elt_val(i, |d| Decodable::decode(d)));
@@ -175,8 +175,8 @@ impl<T> Encodable for HashSet<T> where T: Encodable + Hash + Eq {
 
 impl<T> Decodable for HashSet<T> where T: Decodable + Hash + Eq, {
     fn decode<D: Decoder>(d: &mut D) -> Result<HashSet<T>, D::Error> {
-        d.read_seq(|d, len| {
-            let mut set = HashSet::with_capacity(len);
+        d.read_seq(|d, len, capacity| {
+            let mut set = HashSet::with_capacity(capacity);
             for i in 0..len {
                 set.insert(try!(d.read_seq_elt(i, |d| Decodable::decode(d))));
             }

--- a/src/json.rs
+++ b/src/json.rs
@@ -2245,7 +2245,7 @@ impl ::Decoder for Decoder {
     fn read_tuple<T, F>(&mut self, tuple_len: usize, f: F) -> DecodeResult<T> where
         F: FnOnce(&mut Decoder) -> DecodeResult<T>,
     {
-        self.read_seq(move |d, len| {
+        self.read_seq(move |d, len, _| {
             if len == tuple_len {
                 f(d)
             } else {
@@ -2289,14 +2289,14 @@ impl ::Decoder for Decoder {
     }
 
     fn read_seq<T, F>(&mut self, f: F) -> DecodeResult<T> where
-        F: FnOnce(&mut Decoder, usize) -> DecodeResult<T>,
+        F: FnOnce(&mut Decoder, usize, usize) -> DecodeResult<T>,
     {
         let array = try!(expect!(self.pop(), Array));
         let len = array.len();
         for v in array.into_iter().rev() {
             self.stack.push(v);
         }
-        f(self, len)
+        f(self, len, len)
     }
 
     fn read_seq_elt<T, F>(&mut self, _idx: usize, f: F) -> DecodeResult<T> where
@@ -2306,7 +2306,7 @@ impl ::Decoder for Decoder {
     }
 
     fn read_map<T, F>(&mut self, f: F) -> DecodeResult<T> where
-        F: FnOnce(&mut Decoder, usize) -> DecodeResult<T>,
+        F: FnOnce(&mut Decoder, usize, usize) -> DecodeResult<T>,
     {
         let obj = try!(expect!(self.pop(), Object));
         let len = obj.len();
@@ -2314,7 +2314,7 @@ impl ::Decoder for Decoder {
             self.stack.push(value);
             self.stack.push(Json::String(key));
         }
-        f(self, len)
+        f(self, len, len)
     }
 
     fn read_map_elt_key<T, F>(&mut self, _idx: usize, f: F) -> DecodeResult<T> where

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -574,7 +574,7 @@ macro_rules! array {
     ($len:expr, $($idx:expr),*) => {
         impl<T:Decodable> Decodable for [T; $len] {
             fn decode<D: Decoder>(d: &mut D) -> Result<[T; $len], D::Error> {
-                d.read_seq(|d, len| {
+                d.read_seq(|d, len, _capacity| {
                     if len != $len {
                         return Err(d.error("wrong array length"));
                     }

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -175,12 +175,12 @@ pub trait Decoder {
         where F: FnMut(&mut Self, bool) -> Result<T, Self::Error>;
 
     fn read_seq<T, F>(&mut self, f: F) -> Result<T, Self::Error>
-        where F: FnOnce(&mut Self, usize) -> Result<T, Self::Error>;
+        where F: FnOnce(&mut Self, usize, usize) -> Result<T, Self::Error>;
     fn read_seq_elt<T, F>(&mut self, idx: usize, f: F) -> Result<T, Self::Error>
         where F: FnOnce(&mut Self) -> Result<T, Self::Error>;
 
     fn read_map<T, F>(&mut self, f: F) -> Result<T, Self::Error>
-        where F: FnOnce(&mut Self, usize) -> Result<T, Self::Error>;
+        where F: FnOnce(&mut Self, usize, usize) -> Result<T, Self::Error>;
     fn read_map_elt_key<T, F>(&mut self, idx: usize, f: F)
                               -> Result<T, Self::Error>
         where F: FnOnce(&mut Self) -> Result<T, Self::Error>;
@@ -454,8 +454,8 @@ impl<T:Encodable> Encodable for Vec<T> {
 
 impl<T:Decodable> Decodable for Vec<T> {
     fn decode<D: Decoder>(d: &mut D) -> Result<Vec<T>, D::Error> {
-        d.read_seq(|d, len| {
-            let mut v = Vec::with_capacity(len);
+        d.read_seq(|d, len, capacity| {
+            let mut v = Vec::with_capacity(capacity);
             for i in 0..len {
                 v.push(try!(d.read_seq_elt(i, |d| Decodable::decode(d))));
             }
@@ -660,8 +660,8 @@ impl<D: Decoder> DecoderHelpers for D {
     fn read_to_vec<T, F>(&mut self, mut f: F) -> Result<Vec<T>, D::Error> where F:
         FnMut(&mut D) -> Result<T, D::Error>,
     {
-        self.read_seq(|this, len| {
-            let mut v = Vec::with_capacity(len);
+        self.read_seq(|this, len, capacity| {
+            let mut v = Vec::with_capacity(capacity);
             for i in 0..len {
                 v.push(try!(this.read_seq_elt(i, |this| f(this))));
             }


### PR DESCRIPTION
This is a solution to https://github.com/rust-lang/rustc-serialize/issues/115

It is a breaking change, but will only break people that implement their own `Decoders`, not everyone that uses Decodables.  