### PR TITLE
Prevent arithmetic overflow in to_base64 when specifying line_length

### DIFF
--- a/src/base64.rs
+++ b/src/base64.rs
@@ -105,7 +105,10 @@ impl ToBase64 for [u8] {
         // Preallocate memory.
         let mut prealloc_len = (len + 2) / 3 * 4;
         if let Some(line_length) = config.line_length {
-            let num_lines = (prealloc_len - 1) / line_length;
+            let num_lines = match prealloc_len {
+                0 => 0,
+                n => (n - 1) / line_length
+            };
             prealloc_len += num_lines * newline.bytes().count();
         }
 

--- a/src/base64.rs
+++ b/src/base64.rs
@@ -408,6 +408,11 @@ mod tests {
     }
 
     #[test]
+    fn test_to_base64_empty_line_length() {
+        [].to_base64(Config {line_length: Some(72), ..STANDARD});
+    }
+
+    #[test]
     fn test_from_base64_basic() {
         assert_eq!("".from_base64().unwrap(), b"");
         assert_eq!("Zg==".from_base64().unwrap(), b"f");


### PR DESCRIPTION
Check for an empty length when calculating the number of lines in the input to prevent the arithmetic overflow panic. 
Fixes #143. 