### PR TITLE
Correct parsing of negative zero

### DIFF
--- a/src/json.rs
+++ b/src/json.rs
@@ -1492,6 +1492,8 @@ impl<T: Iterator<Item = char>> Parser<T> {
                 // Make sure we don't underflow.
                 if res > (i64::MAX as u64) + 1 {
                     Error(SyntaxError(InvalidNumber, self.line, self.col))
+                } else if res == 0 {
+                    I64Value(res as i64)
                 } else {
                     I64Value((!res + 1) as i64)
                 }

--- a/src/json.rs
+++ b/src/json.rs
@@ -3424,6 +3424,11 @@ mod tests {
             _ => {} // it parsed and we are good to go
         }
     }
+    
+    #[test]
+    fn test_negative_zero() {
+        Json::from_str("{\"test\":-0}").unwrap();
+    }
 
     #[test]
     fn test_prettyencode_hashmap_with_numeric_key() {


### PR DESCRIPTION
If one tries to parse negative zero with `Json::from_str()`, computing the 2's complement of zero causes an arithmetic overflow. Check for this condition before computing the 2's complement and just return zero, since that is the 2's complement of zero anyway.
Fixes #109 