### PR TITLE
Return a SyntaxError instead of panicking on invalid input

### DIFF
--- a/src/json.rs
+++ b/src/json.rs
@@ -3937,4 +3937,12 @@ mod tests {
         let d = super::decode(&s).unwrap();
         assert_eq!(f, d);
     }
+
+    #[test]
+    fn test_unexpected_token() {
+        match Json::from_str("{\"\":\"\",\"\":{\"\":\"\",\"\":[{\"\":\"\",}}}") {
+            Err(e) => assert_eq!(e, SyntaxError(InvalidSyntax, 1, 32)),
+            _ => ()
+        };
+    }
 }

--- a/src/json.rs
+++ b/src/json.rs
@@ -1932,7 +1932,7 @@ impl<T: Iterator<Item = char>> Builder<T> {
         match self.token.take() {
             None => {}
             Some(Error(e)) => { return Err(e); }
-            ref tok => { panic!("unexpected token {:?}", tok); }
+            _ => { return Err(SyntaxError(InvalidSyntax, self.parser.line, self.parser.col)); }
         }
         result
     }


### PR DESCRIPTION
Fixes #110