### PR TITLE
Cap calls to with_capacity with sane default

### DIFF
--- a/src/collection_impls.rs
+++ b/src/collection_impls.rs
@@ -12,7 +12,7 @@
 
 use std::hash::Hash;
 
-use {Decodable, Encodable, Decoder, Encoder};
+use {Decodable, Encodable, Decoder, Encoder, cap_capacity};
 use std::collections::{LinkedList, VecDeque, BTreeMap, BTreeSet, HashMap, HashSet};
 
 impl<
@@ -149,7 +149,7 @@ impl<K, V> Decodable for HashMap<K, V>
 {
     fn decode<D: Decoder>(d: &mut D) -> Result<HashMap<K, V>, D::Error> {
         d.read_map(|d, len| {
-            let mut map = HashMap::with_capacity(len);
+            let mut map = HashMap::with_capacity(cap_capacity::<(K, V)>(len));
             for i in 0..len {
                 let key = try!(d.read_map_elt_key(i, |d| Decodable::decode(d)));
                 let val = try!(d.read_map_elt_val(i, |d| Decodable::decode(d)));
@@ -176,7 +176,7 @@ impl<T> Encodable for HashSet<T> where T: Encodable + Hash + Eq {
 impl<T> Decodable for HashSet<T> where T: Decodable + Hash + Eq, {
     fn decode<D: Decoder>(d: &mut D) -> Result<HashSet<T>, D::Error> {
         d.read_seq(|d, len| {
-            let mut set = HashSet::with_capacity(len);
+            let mut set = HashSet::with_capacity(cap_capacity::<T>(len));
             for i in 0..len {
                 set.insert(try!(d.read_seq_elt(i, |d| Decodable::decode(d))));
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,20 @@
 pub use self::serialize::{Decoder, Encoder, Decodable, Encodable,
                           DecoderHelpers, EncoderHelpers};
 
+
+// Limit collections from allocating more than
+// 1 MB for calls to `with_capacity`.
+fn cap_capacity<T>(given_len: usize) -> usize {
+    use std::cmp::min;
+    use std::mem::size_of;
+    const PRE_ALLOCATE_CAP: usize = 0x100000;
+
+    match size_of::<T>() {
+        0 => min(given_len, PRE_ALLOCATE_CAP),
+        n => min(given_len, PRE_ALLOCATE_CAP / n)
+    }
+}
+
 mod serialize;
 mod collection_impls;
 


### PR DESCRIPTION
For instances where the length of a collection must be obeyed, but is
untrusted, calls to with_capacity() could result in OOM errors.

This change makes it so that collections don't pre-allocate more than
1MB of memory.