### PR TITLE
added into_* variations for as_object, as_array

### DIFF
--- a/src/json.rs
+++ b/src/json.rs
@@ -1023,7 +1023,7 @@ impl Json {
         self.as_object().is_some()
     }
 
-    /// If the Json value is an Object, returns the associated BTreeMap.
+    /// If the Json value is an Object, returns a reference to the associated BTreeMap.
     /// Returns None otherwise.
     pub fn as_object<'a>(&'a self) -> Option<&'a Object> {
         match self {
@@ -1032,11 +1032,20 @@ impl Json {
         }
     }
 
-    /// If the Json value is an Object, returns the associated mutable BTreeMap.
+    /// If the Json value is an Object, returns a mutable reference to the associated BTreeMap.
     /// Returns None otherwise.
     pub fn as_object_mut<'a>(&'a mut self) -> Option<&'a mut Object> {
         match self {
             &mut Json::Object(ref mut map) => Some(map),
+            _ => None
+        }
+    }
+
+    /// If the Json value is an Object, returns the associated BTreeMap.
+    /// Returns None otherwise.
+    pub fn into_object(self) -> Option<Object> {
+        match self {
+            Json::Object(map) => Some(map),
             _ => None
         }
     }
@@ -1046,7 +1055,7 @@ impl Json {
         self.as_array().is_some()
     }
 
-    /// If the Json value is an Array, returns the associated vector.
+    /// If the Json value is an Array, returns a reference to the associated vector.
     /// Returns None otherwise.
     pub fn as_array<'a>(&'a self) -> Option<&'a Array> {
         match self {
@@ -1055,11 +1064,20 @@ impl Json {
         }
     }
 
-    /// If the Json value is an Array, returns the associated mutable vector.
+    /// If the Json value is an Array, returns a mutable reference to the associated vector.
     /// Returns None otherwise.
     pub fn as_array_mut<'a>(&'a mut self) -> Option<&'a mut Array> {
         match self {
             &mut Json::Array(ref mut list) => Some(list),
+            _ => None
+        }
+    }
+
+    /// If the Json value is an Array, returns the associated vector.
+    /// Returns None otherwise.
+    pub fn into_array(self) -> Option<Array> {
+        match self {
+            Json::Array(array) => Some(array),
             _ => None
         }
     }
@@ -3426,7 +3444,7 @@ mod tests {
             _ => {} // it parsed and we are good to go
         }
     }
-    
+
     #[test]
     fn test_negative_zero() {
         Json::from_str("{\"test\":-0}").unwrap();


### PR DESCRIPTION
Allows a the destructuring of a Json type with move semantics.

For example,
```rust
let json_value = Json::from_str("{}").unwrap();
let json_object = (|json: Json| {
    // doesn't compile
    json.as_object()
})(json_value);
assert!(json_object.is_some());
```

if a Json type is passed to a closure, or some other scope block, when trying to destructure it, there is a lifetime conflict. The Json given as a parameter to the closure was moved, but it cannot be moved out of the closure as an Object.

If you replace as_object with into_object, the Object value returned is not a reference, so it can be moved out of the scope.

But this works,
```rust
let json_value = Json::from_str("{}").unwrap();
let json_object = (|json: Json| {
    json.into_object()
})(json_value);
assert!(json_object.is_some());
```