### PR TITLE
EncoderError: derive PartialEq

### DIFF
--- a/src/json.rs
+++ b/src/json.rs
@@ -331,7 +331,7 @@ pub enum DecoderError {
     EOF,
 }
 
-#[derive(Copy, Debug)]
+#[derive(Copy, PartialEq, Debug)]
 pub enum EncoderError {
     FmtError(fmt::Error),
     BadHashmapKey,


### PR DESCRIPTION
Makes writing serialization tests easier