### PR TITLE
implementations with ?Sized for Hex and Base64 traits

### DIFF
--- a/src/base64.rs
+++ b/src/base64.rs
@@ -191,6 +191,12 @@ impl ToBase64 for [u8] {
     }
 }
 
+impl<'a, T: ?Sized + ToBase64> ToBase64 for &'a T {
+    fn to_base64(&self, config: Config) -> String {
+        (**self).to_base64(config)
+    }
+}
+
 /// A trait for converting from base64 encoded values.
 pub trait FromBase64 {
     /// Converts the value of `self`, interpreted as base64 encoded data, into
@@ -314,6 +320,12 @@ impl FromBase64 for [u8] {
         }
 
         Ok(r)
+    }
+}
+
+impl<'a, T: ?Sized + FromBase64> FromBase64 for &'a T {
+    fn from_base64(&self) -> Result<Vec<u8>, FromBase64Error> {
+        (**self).from_base64()
     }
 }
 

--- a/src/hex.rs
+++ b/src/hex.rs
@@ -53,6 +53,12 @@ impl ToHex for [u8] {
     }
 }
 
+impl<'a, T: ?Sized + ToHex> ToHex for &'a T {
+    fn to_hex(&self) -> String {
+        (**self).to_hex()
+    }
+}
+
 /// A trait for converting hexadecimal encoded values
 pub trait FromHex {
     /// Converts the value of `self`, interpreted as hexadecimal encoded data,
@@ -152,6 +158,12 @@ impl FromHex for str {
             0 => Ok(b.into_iter().collect()),
             _ => Err(InvalidHexLength),
         }
+    }
+}
+
+impl<'a, T: ?Sized + FromHex> FromHex for &'a T {
+    fn from_hex(&self) -> Result<Vec<u8>, FromHexError> {
+        (**self).from_hex()
     }
 }
 


### PR DESCRIPTION
I was trying to use the Hex and Base64 traits with generics and that just didn't work for me.
After some digging around and learning a bit about Sized, I was able to find the solution to my problem.
I saw the needed implementation already existed in [serialize.rs for Encodable](https://github.com/rust-lang-nursery/rustc-serialize/blob/6488e2b61fa7d6ed7b7ca1028316db0ea40af861/src/serialize.rs#L1105), so I added the missing pieces of code to both Hex and Base64.

Here's a small example of usage, to show what was missing.
```
extern crate rustc_serialize;

use rustc_serialize::hex::{ToHex, FromHex, FromHexError};
use rustc_serialize::base64::{ToBase64, FromBase64, FromBase64Error};
use rustc_serialize::base64;

fn hex_to_base64<T: FromHex>(buf: &T) -> Result<String, FromHexError> {
	Ok(try!(buf.from_hex()).to_base64(base64::STANDARD))
}

fn base64_to_hex<T: FromBase64>(buf: &T) -> Result<String, FromBase64Error> {
	Ok(try!(buf.from_base64()).to_hex())
}


trait AsHexToBase64 : FromHex {
	fn as_hex_to_base64(&self) -> Result<String, FromHexError> {
		Ok(try!(self.from_hex()).to_base64(base64::STANDARD))
	}
}

trait AsBase64ToHex : FromBase64 {
	fn as_base64_to_hex(&self) -> Result<String, FromBase64Error> {
		Ok(try!(self.from_base64()).to_hex())
	}
}

impl<'a, T: ?Sized + FromHex> AsHexToBase64 for &'a T {}
impl<'a, T: ?Sized + FromBase64> AsBase64ToHex for &'a T {}


fn main() {
	let buf = "This is a TEST!~ D:".as_bytes();
	let buf_hex = "5468697320697320612054455354217e20443a";
	let buf_base64 = "VGhpcyBpcyBhIFRFU1QhfiBEOg==";

	assert_eq!(buf.to_hex(), buf_hex);
	assert_eq!(buf.to_base64(base64::STANDARD), buf_base64);

	assert_eq!(buf_hex.from_hex().unwrap(), buf);
	assert_eq!(buf_base64.from_base64().unwrap(), buf);

	// did not work before
	assert_eq!(hex_to_base64(&buf_hex).unwrap(), buf_base64);
	assert_eq!(base64_to_hex(&buf_base64).unwrap(), buf_hex);

	// did not work before
	assert_eq!(buf_hex.as_hex_to_base64().unwrap(), buf_base64);
	assert_eq!(buf_base64.as_base64_to_hex().unwrap(), buf_hex);
}
```
