### PR TITLE
More precise identification of Redox target

### DIFF
--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -1309,7 +1309,7 @@ array! {
 }
 
 impl Encodable for path::Path {
-    #[cfg(redox)]
+    #[cfg(target_os = "redox")]
     fn encode<S: Encoder>(&self, e: &mut S) -> Result<(), S::Error> {
         self.as_os_str().to_str().unwrap().encode(e)
     }
@@ -1333,7 +1333,7 @@ impl Encodable for path::PathBuf {
 }
 
 impl Decodable for path::PathBuf {
-    #[cfg(redox)]
+    #[cfg(target_os = "redox")]
     fn decode<D: Decoder>(d: &mut D) -> Result<path::PathBuf, D::Error> {
         let string: String = try!(Decodable::decode(d));
         let s: OsString = OsString::from(string);


### PR DESCRIPTION
This is a minor change to match the way that the `libc` and `rand` crates now have checking for Redox. It is more accurate than checking for `cfg(redox)`.