### PR TITLE
Fix automated code update mistake

### DIFF
--- a/src/base64.rs
+++ b/src/base64.rs
@@ -392,7 +392,7 @@ mod tests {
 
     #[test]
     fn test_to_base64_crlf_line_break() {
-        assert!(![08; 1000].to_base64(Config {line_length: None, ..STANDARD})
+        assert!(![0; 1000].to_base64(Config {line_length: None, ..STANDARD})
                               .contains("\r\n"));
         assert_eq!(b"foobar".to_base64(Config {line_length: Some(4),
                                                ..STANDARD}),
@@ -401,7 +401,7 @@ mod tests {
 
     #[test]
     fn test_to_base64_lf_line_break() {
-        assert!(![08; 1000].to_base64(Config {line_length: None,
+        assert!(![0; 1000].to_base64(Config {line_length: None,
                                                  newline: Newline::LF,
                                                  ..STANDARD})
                               .contains("\n"));

--- a/src/hex.rs
+++ b/src/hex.rs
@@ -128,7 +128,7 @@ impl FromHex for str {
         // This may be an overestimate if there is any whitespace
         let mut b = Vec::with_capacity(self.len() / 2);
         let mut modulus = 0;
-        let mut buf = 08;
+        let mut buf = 0;
 
         for (idx, byte) in self.bytes().enumerate() {
             buf <<= 4;


### PR DESCRIPTION
This was introduced in https://github.com/rust-lang-nursery/rustc-serialize/commit/49d4958b2e88335e586b18734ee1ae1cde5e0da1#diff-afe95bd2eae65804dddefc843cd57bb5R126, `0u8` was mistakenly replaced by `08` instead of `0`.
Due to luck, this mistake does not have any consequences, but it is still confusing when reading the code.
